### PR TITLE
Add merge preference for vault files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
+
+# Always prefer local vault changes during merges to avoid noisy conflicts
+obsidian/** merge=ours


### PR DESCRIPTION
## Summary
- configure .gitattributes to always keep the branch version of Obsidian vault files during merges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0f06bb94832888891459a2a12d71