### PR TITLE
chore: clean up lint warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,9 +14,9 @@ from dash import (
     Input,
     Output,
     State,
+    dash_table,
     dcc,
     html,
-    dash_table,
 )
 from dotenv import load_dotenv
 from flask import Flask, jsonify
@@ -256,7 +256,8 @@ def make_ai_tab() -> html.Div:
             [
                 html.H3("AI Assistant"),
                 html.P(
-                    "OpenAI API key not configured. Add OPENAI_API_KEY to .env to enable AI features.",
+                    "OpenAI API key not configured. Add OPENAI_API_KEY to .env to enable AI "
+                    "features.",
                 ),
             ]
         )

--- a/rizzk/core/data.py
+++ b/rizzk/core/data.py
@@ -14,10 +14,10 @@ import pandas as pd
 class DataSource:
     """Interface for retrieving data for the UI."""
 
-    def get_ohlc(self, symbol: str, days: int = 200) -> pd.DataFrame:  # pragma: no cover - interface
+    def get_ohlc(self, symbol: str, days: int = 200) -> pd.DataFrame:  # pragma: no cover
         raise NotImplementedError
 
-    def get_news(self, symbol: str, limit: int = 20) -> list[dict]:  # pragma: no cover - interface
+    def get_news(self, symbol: str, limit: int = 20) -> list[dict]:  # pragma: no cover
         raise NotImplementedError
 
 

--- a/rizzk/core/settings.py
+++ b/rizzk/core/settings.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Mapping
 
 from dotenv import dotenv_values
 

--- a/rizzk/core/util.py
+++ b/rizzk/core/util.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def humanize_timestamp(ts: int) -> str:
     """Return a human readable timestamp string in UTC."""
-    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return datetime.fromtimestamp(ts, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")


### PR DESCRIPTION
## Summary
- reorder Dash imports and wrap long strings to satisfy ruff formatting checks
- shorten abstract method coverage pragmas to respect line-length constraints
- adopt stdlib typing and datetime aliases recommended by ruff

## Testing
- ruff check
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de7d1cd334832892cb64f12dbdc052